### PR TITLE
Fix trivial clippy warnings

### DIFF
--- a/rust/src/election.rs
+++ b/rust/src/election.rs
@@ -131,6 +131,7 @@ pub struct Election<'a> {
     follower_fn: Arc<Box<Fn() -> () + Send + Sync + 'a>>,
 }
 
+#[derive(Clone, Copy)]
 pub enum Handler {
     Leader,
     Follower,
@@ -156,11 +157,10 @@ impl<'a> Election<'a> {
         let leader_fn = self.leader_fn.clone();
         let follower_fn = self.follower_fn.clone();
         self.running.store(true, Ordering::Relaxed);
-        while self.is_running() {
+        if self.is_running() {
             self.lock.lock(|| leader_fn());
 
             follower_fn();
-            break;
         }
     }
 

--- a/rust/src/lock.rs
+++ b/rust/src/lock.rs
@@ -16,7 +16,7 @@ use std::time::{Duration};
 use requests::{get, put, Error, StatusCode};
 
 
-pub const DEFAULT_BASE_URI: &'static str = "http://localhost:8080";
+pub const DEFAULT_BASE_URI: &str = "http://localhost:8080";
 
 
 


### PR DESCRIPTION
This fixes some trivial clippy warnings in the rust code.

The most interesting one was the while loop, as that really did only run once.