### PR TITLE
Fix some clippy lints

### DIFF
--- a/rust/src/election.rs
+++ b/rust/src/election.rs
@@ -156,11 +156,10 @@ impl<'a> Election<'a> {
         let leader_fn = self.leader_fn.clone();
         let follower_fn = self.follower_fn.clone();
         self.running.store(true, Ordering::Relaxed);
-        while self.is_running() {
+        if self.is_running() {
             self.lock.lock(|| leader_fn());
 
             follower_fn();
-            break;
         }
     }
 

--- a/rust/src/election.rs
+++ b/rust/src/election.rs
@@ -131,6 +131,7 @@ pub struct Election<'a> {
     follower_fn: Arc<Box<Fn() -> () + Send + Sync + 'a>>,
 }
 
+#[derive(Copy, Clone)]
 pub enum Handler {
     Leader,
     Follower,

--- a/rust/src/lock.rs
+++ b/rust/src/lock.rs
@@ -16,7 +16,7 @@ use std::time::{Duration};
 use requests::{get, put, Error, StatusCode};
 
 
-pub const DEFAULT_BASE_URI: &'static str = "http://localhost:8080";
+pub const DEFAULT_BASE_URI: &str = "http://localhost:8080";
 
 
 


### PR DESCRIPTION
All &str are 'static by default so its not needed; a while loop that just breaks is the same as an if statement and Handler can derive copy because it isn't data expensive and it stops lints about passing it by reference.